### PR TITLE
Create grid layout tutorial page

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,9 @@ repos:
     rev: 5.0.2
     hooks:
       - id: flake8
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: "v2.7.1"
+    hooks:
+      - id: prettier
+        types_or: [css, javascript]

--- a/src/learnastropytutorialtheme/templates/html/astropy-footer.html.j2
+++ b/src/learnastropytutorialtheme/templates/html/astropy-footer.html.j2
@@ -1,0 +1,1 @@
+<footer class="at-tutorial-footer">Astropy footer</footer>

--- a/src/learnastropytutorialtheme/templates/html/astropy-header.html.j2
+++ b/src/learnastropytutorialtheme/templates/html/astropy-header.html.j2
@@ -1,0 +1,1 @@
+<header>Header content</header>

--- a/src/learnastropytutorialtheme/templates/html/astropy-header.html.j2
+++ b/src/learnastropytutorialtheme/templates/html/astropy-header.html.j2
@@ -1,1 +1,11 @@
-<header>Header content</header>
+<header>
+  <p class="at-logotext"><a href="https://learn.astropy.org">
+    <span class="at-logotext__primary">Learn.Astropy</span>
+    <span class="at-logotext__divider">/</span>
+    <span class="at-logotext__secondary">Tutorials</span>
+  </a></p>
+  <nav class="at-header-nav">
+    <a href="https://mybinder.org/v2/gh/astropy/astropy-tutorials/main?labpath=tutorials%2Fcolor-excess%2Fcolor-excess.ipynb">Open in Binder</a>
+    <a href="https://learn.astropy.org/tutorials/color-excess.ipynb" download>Download notebook</a>
+  </nav>
+</header>

--- a/src/learnastropytutorialtheme/templates/html/astropy-sidebar.html.j2
+++ b/src/learnastropytutorialtheme/templates/html/astropy-sidebar.html.j2
@@ -1,0 +1,1 @@
+<nav class="at-notebook-sidebar">Sidebar content</nav>

--- a/src/learnastropytutorialtheme/templates/html/astropytutorial.css
+++ b/src/learnastropytutorialtheme/templates/html/astropytutorial.css
@@ -1,3 +1,7 @@
+:root {
+  --astropy-primary-color: #fa743b;
+}
+
 body {
   display: grid;
   grid-template-columns: 18rem 1fr;
@@ -14,6 +18,10 @@ header {
   padding: 0.5rem;
   background-color: #000;
   color: #fff;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: baseline;
 }
 
 main {
@@ -29,4 +37,35 @@ main {
 .at-tutorial-footer {
   grid-area: 3 / 1 / 4 / 3;
   padding: 0.5rem;
+}
+
+.at-logotext {
+  font-size: 1.2rem;
+}
+
+.at-logotext a:hover {
+  color: var(--astropy-primary-color);
+}
+
+.at-logotext__primary {
+  font-weight: bold;
+}
+
+.at-logotext__divider {
+  opacity: 50%;
+  color: var(--astropy-primary-color);
+}
+
+.at-header-nav {
+  display: flex;
+  font-weight: bold;
+}
+
+.at-header-nav a {
+  margin-left: 1.5rem;
+}
+
+.at-header-nav a:hover {
+  color: var(--astropy-primary-color);
+  text-decoration: underline;
 }

--- a/src/learnastropytutorialtheme/templates/html/astropytutorial.css
+++ b/src/learnastropytutorialtheme/templates/html/astropytutorial.css
@@ -69,3 +69,9 @@ main {
   color: var(--astropy-primary-color);
   text-decoration: underline;
 }
+
+.at-tutorial-footer {
+  margin-top: 2rem;
+  border-top: 1px solid var(--astropy-primary-color);
+  width: 100%;
+}

--- a/src/learnastropytutorialtheme/templates/html/astropytutorial.css
+++ b/src/learnastropytutorialtheme/templates/html/astropytutorial.css
@@ -1,0 +1,32 @@
+body {
+  display: grid;
+  grid-template-columns: 18rem 1fr;
+  grid-template-rows: auto 1fr auto;
+}
+
+body.jp-Notebook {
+  padding: 0;
+  margin: 0;
+}
+
+header {
+  grid-area: 1 / 1 / 2 / 3;
+  padding: 0.5rem;
+  background-color: #000;
+  color: #fff;
+}
+
+main {
+  grid-area: 2 / 2 / 3 / 3;
+  max-width: 60rem;
+}
+
+.at-notebook-sidebar {
+  grid-area: 2 / 1 / 3 / 2;
+  padding: 0.5rem;
+}
+
+.at-tutorial-footer {
+  grid-area: 3 / 1 / 4 / 3;
+  padding: 0.5rem;
+}

--- a/src/learnastropytutorialtheme/templates/html/index.html.j2
+++ b/src/learnastropytutorialtheme/templates/html/index.html.j2
@@ -166,7 +166,6 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 {% include "astropy-header.html.j2" %}
 
 {% include "astropy-sidebar.html.j2" %}
-<header>Header content</header>
 
 <nav class="at-notebook-sidebar">Sidebar content</nav>
 

--- a/src/learnastropytutorialtheme/templates/html/index.html.j2
+++ b/src/learnastropytutorialtheme/templates/html/index.html.j2
@@ -162,6 +162,10 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 {%- endblock body_header -%}
 
 {% block body_loop %}
+
+{% include "astropy-header.html.j2" %}
+
+{% include "astropy-sidebar.html.j2" %}
 <header>Header content</header>
 
 <nav class="at-notebook-sidebar">Sidebar content</nav>

--- a/src/learnastropytutorialtheme/templates/html/index.html.j2
+++ b/src/learnastropytutorialtheme/templates/html/index.html.j2
@@ -42,6 +42,7 @@
 {% else %}
     {{ resources.include_lab_theme(resources.theme) }}
 {% endif %}
+{{ resources.include_css("astropytutorial.css") }}
 <style type="text/css">
 /* Force rendering true colors when outputing to pdf */
 * {
@@ -159,6 +160,18 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 <body class="jp-Notebook" data-jp-theme-light="true" data-jp-theme-name="JupyterLab Light">
 {% endif %}
 {%- endblock body_header -%}
+
+{% block body_loop %}
+<header>Header content</header>
+
+<nav class="at-notebook-sidebar">Sidebar content</nav>
+
+<main class="at-notebook-wrapper">
+{{ super() }}
+</main>
+
+<footer class="at-tutorial-footer">Astropy footer</footer>
+{% endblock body_loop %}
 
 {% block body_footer %}
 </body>


### PR DESCRIPTION
We'll use astropytutorial.css to load all the custom CSS needed for the astropy tutorial theming.

Note that notebook cells were originally direct descendants of `<body>`; now we're putting that content in `<main>` and adding additional `header`, `nav`, and `footer` elements around it.

We've mocked up links to Binder and for downloading the notebook; next we need to route Jinja templating context to set this data properly.