### PR TITLE
Integrate context from Tutorials GitHub repo into theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # Learn Astropy Tutorial Theme
 
 This is an [nbconvert](https://nbconvert.readthedocs.io/) custom exporter and template for Learn Astropy's Jupyter notebook-based tutorials.
+
+## Resources schema
+
+The Learn Astropy Tutorial Theme can add links to the rendered notebook HTML to make the page work within the larger Learn Astropy site.
+These links are
+You can configure these links by setting the `resources` parameter when running the HTML exporter (e.g. with the `LearnAstropyHtmlExporter.from_filename` method) with a dictionary containing the following keys:
+
+- `learn_astropy_editor_url`. The URL to the notebook in an online notebook viewer/editor, such as Binder. The user must compute the full URL. Omit this field if you do not want to include a link to an online editor.
+- `learn_astropy_editor_label`. The text for the link to the editor. Defaults to "Open in Binder".
+- `learn-astropy_source_url`. The URL to the notebook in a source code repository, such as GitHub. Omit this field if you do not want to include a link to the source code.
+- `learn_astropy_source_label`. The text for the link to the source code. Defaults to "View on GitHub".
+- `learn_astropy_ipynb_download_url`. The URL to download this notebook as a Jupyter notebook file. Omit this field if you do not want to include a link to download the notebook.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dev = [
 Source = "https://github.com/jsickcodes/learn-astropy-tutorial-theme"
 
 [project.entry-points."nbconvert.exporters"]
-learn-astropy = "learnastropytutorialtheme.exporter:LearnAstropyExporter"
+learn-astropy = "learnastropytutorialtheme.html:LearnAstropyExporter"
 
 [build-system]
 requires = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ dev = [
 [project.urls]
 Source = "https://github.com/jsickcodes/learn-astropy-tutorial-theme"
 
+[project.entry-points."nbconvert.exporters"]
+learn-astropy = "learnastropytutorialtheme.exporter:LearnAstropyExporter"
+
 [build-system]
 requires = [
     "setuptools>=61",

--- a/src/learnastropytutorialtheme/html.py
+++ b/src/learnastropytutorialtheme/html.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 from nbconvert.exporters.html import HTMLExporter
 
@@ -13,15 +13,17 @@ class LearnAstropyHtmlExporter(HTMLExporter):
 
     export_from_notebook = "Learn Astropy HTML"
 
-    @property
-    def extra_template_basedirs(self) -> List[str]:
-        """Include this package's built-in template in the search path."""
-        _paths = super()._default_extra_template_basedirs()
-        _paths.append(self._template_name_default())
-        return _paths
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+        # Add the default template to the search path
+        self.extra_template_basedirs.append(self._template_name_default())
 
     def _template_name_default(self) -> str:
-        """Select built-in HTML theme as the default."""
+        """Select built-in HTML theme as the default.
+
+        Overrides `HTMLExporter._template_name_default`.
+        """
         return str(
             Path(__file__).parent.joinpath("templates").joinpath("html")
         )

--- a/src/learnastropytutorialtheme/html.py
+++ b/src/learnastropytutorialtheme/html.py
@@ -35,7 +35,4 @@ class LearnAstropyHtmlExporter(HTMLExporter):
         resources = super()._init_resources(resources)
         resources["Learn"] = "Astropy!"
 
-        # Toggle between 'light' and 'dark' themes
-        resources["theme"] = "light"
-
         return resources

--- a/src/learnastropytutorialtheme/html.py
+++ b/src/learnastropytutorialtheme/html.py
@@ -32,4 +32,8 @@ class LearnAstropyHtmlExporter(HTMLExporter):
         """
         resources = super()._init_resources(resources)
         resources["Learn"] = "Astropy!"
+
+        # Toggle between 'light' and 'dark' themes
+        resources["theme"] = "light"
+
         return resources

--- a/src/learnastropytutorialtheme/html.py
+++ b/src/learnastropytutorialtheme/html.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List
+from typing import Any, Dict, List
 
 from nbconvert.exporters.html import HTMLExporter
 
@@ -25,3 +25,11 @@ class LearnAstropyHtmlExporter(HTMLExporter):
         return str(
             Path(__file__).parent.joinpath("templates").joinpath("html")
         )
+
+    def _init_resources(self, resources: Dict[str, Any]) -> Dict[str, Any]:
+        """Add additional metadata to the Jinja context via the resources
+        dictionary.
+        """
+        resources = super()._init_resources(resources)
+        resources["Learn"] = "Astropy!"
+        return resources

--- a/src/learnastropytutorialtheme/templates/html/astropy-header.html.j2
+++ b/src/learnastropytutorialtheme/templates/html/astropy-header.html.j2
@@ -1,11 +1,18 @@
 <header>
   <p class="at-logotext"><a href="https://learn.astropy.org">
-    <span class="at-logotext__primary">Learn.Astropy</span>
-    <span class="at-logotext__divider">/</span>
-    <span class="at-logotext__secondary">Tutorials</span>
-  </a></p>
+      <span class="at-logotext__primary">Learn.Astropy</span>
+      <span class="at-logotext__divider">/</span>
+      <span class="at-logotext__secondary">Tutorials</span>
+    </a></p>
   <nav class="at-header-nav">
-    <a href="https://mybinder.org/v2/gh/astropy/astropy-tutorials/main?labpath=tutorials%2Fcolor-excess%2Fcolor-excess.ipynb">Open in Binder</a>
-    <a href="https://learn.astropy.org/tutorials/color-excess.ipynb" download>Download notebook</a>
+    {% if resources.learn_astropy_editor_url %}
+    <a href="{{ resources['learn_astropy_editor_url'] }}">{{ resources["learn_astropy_editor_label"] or "Open in Binder" }}</a>
+    {% endif %}
+    {% if resources.learn_astropy_source_url %}
+    <a href="{{ resources['learn_astropy_source_url'] }}">{{ resources["learn_astropy_source_label"] or "View on GitHub" }}</a>
+    {% endif %}
+    {% if resources.learn_astropy_ipynb_download_url %}
+    <a href="{{ resources['learn_astropy_ipynb_download_url'] }}" download>Download</a>
+    {% endif %}
   </nav>
 </header>

--- a/src/learnastropytutorialtheme/templates/html/astropy-sidebar.html.j2
+++ b/src/learnastropytutorialtheme/templates/html/astropy-sidebar.html.j2
@@ -1,1 +1,15 @@
-<nav class="at-notebook-sidebar">Sidebar content</nav>
+<nav class="at-notebook-sidebar">
+
+<pre>
+{{ resources['Learn'] }}
+</pre>
+
+<pre>
+{{ resources['metadata']['name'] }}
+</pre>
+
+<pre>
+{{ resources['metadata']['path'] }}
+</pre>
+
+</nav>

--- a/src/learnastropytutorialtheme/templates/html/astropytutorial.css
+++ b/src/learnastropytutorialtheme/templates/html/astropytutorial.css
@@ -1,11 +1,27 @@
 :root {
   --astropy-primary-color: #fa743b;
+
+  /* Set base font-size that all rems become relative to. */
+  font-size: 1.2rem;
+}
+
+html {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #000;
 }
 
 body {
   display: grid;
   grid-template-columns: 18rem 1fr;
   grid-template-rows: auto 1fr auto;
+}
+
+/* Set base color tokens for the dark theme. */
+body[jp-theme-light="false"] {
+  color: #fff;
 }
 
 body.jp-Notebook {

--- a/src/learnastropytutorialtheme/templates/html/index.html.j2
+++ b/src/learnastropytutorialtheme/templates/html/index.html.j2
@@ -167,8 +167,6 @@ body[data-format='mobile'] .jp-OutputArea-child .jp-OutputArea-output {
 
 {% include "astropy-sidebar.html.j2" %}
 
-<nav class="at-notebook-sidebar">Sidebar content</nav>
-
 <main class="at-notebook-wrapper">
 {{ super() }}
 </main>

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -5,30 +5,40 @@ from __future__ import annotations
 from copy import deepcopy
 from pathlib import Path
 
+import pytest
+
 from learnastropytutorialtheme.html import LearnAstropyHtmlExporter
 
 from .support.helpers import write_conversion
 
 
-def test_html_export() -> None:
-    """Smoke test for the HTML export.
+@pytest.mark.parametrize("theme", ["light", "dark"])
+def test_html_export(theme: str) -> None:
+    """Integration test for the HTML export with light and dark theme variants.
 
-    Output is written to _build/html_export.
+    Output is written to `_build/{theme}`.
     """
     test_notebook = Path(__file__).parent.joinpath("color-excess.ipynb")
-    html, resources = LearnAstropyHtmlExporter().from_filename(
-        str(test_notebook.resolve())
+
+    resources = {
+        "learn_astropy_editor_url": (
+            "https://mybinder.org/v2/gh/astropy/astropy-tutorials/"
+            "main?labpath=tutorials%2Fcolor-excess%2Fcolor-excess.ipynb"
+        ),
+        "learn_astropy_source_url": (
+            "https://github.com/astropy/astropy-tutorials/blob/main/tutorials/"
+            "color-excess/color-excess.ipynb"
+        ),
+        "learn_astropy_ipynb_download_url": (
+            "https://learn.astropy.org/tutorials/color-excess.ipynb"
+        ),
+    }
+
+    exporter = LearnAstropyHtmlExporter()
+    exporter.theme = theme
+    html, resources = exporter.from_filename(
+        str(test_notebook.resolve()), resources=resources
     )
+
     resources = deepcopy(resources)
-    resources["learn_astropy_editor_url"] = (
-        "https://mybinder.org/v2/gh/astropy/astropy-tutorials/"
-        "main?labpath=tutorials%2Fcolor-excess%2Fcolor-excess.ipynb"
-    )
-    resources["learn_astropy_source_url"] = (
-        "https://github.com/astropy/astropy-tutorials/blob/main/tutorials/"
-        "color-excess/color-excess.ipynb"
-    )
-    resources[
-        "learn_astropy_ipynb_download_url"
-    ] = "https://learn.astropy.org/tutorials/color-excess.ipynb"
-    write_conversion(base_dir="html_export", content=html, resources=resources)
+    write_conversion(base_dir=theme, content=html, resources=resources)

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from pathlib import Path
 
 from learnastropytutorialtheme.html import LearnAstropyHtmlExporter
@@ -18,4 +19,16 @@ def test_html_export() -> None:
     html, resources = LearnAstropyHtmlExporter().from_filename(
         str(test_notebook.resolve())
     )
+    resources = deepcopy(resources)
+    resources["learn_astropy_editor_url"] = (
+        "https://mybinder.org/v2/gh/astropy/astropy-tutorials/"
+        "main?labpath=tutorials%2Fcolor-excess%2Fcolor-excess.ipynb"
+    )
+    resources["learn_astropy_source_url"] = (
+        "https://github.com/astropy/astropy-tutorials/blob/main/tutorials/"
+        "color-excess/color-excess.ipynb"
+    )
+    resources[
+        "learn_astropy_ipynb_download_url"
+    ] = "https://learn.astropy.org/tutorials/color-excess.ipynb"
     write_conversion(base_dir="html_export", content=html, resources=resources)


### PR DESCRIPTION
To populate the download links and the link to Binder, we need to add context to the Jinja templating environment about the repository, and the path of that notebook within the repository.

This PR sets up a schema of metadata that can be added to the `resources` dictionary when running nbconvert. The Jinja templates use this data to populate links to download, open in binder, and open in GitHub:

- `learn_astropy_editor_url`. The URL to the notebook in an online notebook viewer/editor, such as Binder. The user must compute the full URL. Omit this field if you do not want to include a link to an online editor.
- `learn_astropy_editor_label`. The text for the link to the editor. Defaults to "Open in Binder".
- `learn-astropy_source_url`. The URL to the notebook in a source code repository, such as GitHub. Omit this field if you do not want to include a link to the source code.
- `learn_astropy_source_label`. The text for the link to the source code. Defaults to "View on GitHub".
- `learn_astropy_ipynb_download_url`. The URL to download this notebook as a Jupyter notebook file. Omit this field if you do not want to include a link to download the notebook.
